### PR TITLE
Fix typo in property name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
-insert_trailing_newline = true
+insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
There is a typo in the property name `insert_final_newline`. This PR fixes that.